### PR TITLE
Fix various stick recipes

### DIFF
--- a/scripts/BetterNether.zs
+++ b/scripts/BetterNether.zs
@@ -27,4 +27,7 @@ recipes.addShaped(<betternether:cincinnasite_frame> * 4, [[<betternether:cincinn
 # Cincinnasite into Gold Nuggets
 recipes.addShapeless(<minecraft:gold_nugget>, [<betternether:cincinnasite>]);
 
+# Remove unneeded stick recipe
+recipes.removeShaped(<minecraft:stick> * 4, [[<betternether:stalagnate_planks>],[<betternether:stalagnate_planks>]]);
+
 print("ENDING BetterNether.zs");

--- a/scripts/MinecraftRecipes.zs
+++ b/scripts/MinecraftRecipes.zs
@@ -276,4 +276,7 @@ recipes.addShapeless(<minecraft:book>, [<minecraft:paper>,<minecraft:paper>,<min
 # Seeds from Wheat
 recipes.addShapeless(<minecraft:wheat_seeds>, [<minecraft:wheat>]);
 
+# Sticks from Logs
+recipes.addShaped(<minecraft:stick> * 16, [[<ore:logWood>], [<ore:logWood>]]);
+
 print("ENDING MinecraftRecipes.zs");


### PR DESCRIPTION
Add 2 logs to 16 sticks recipe. 

I tested this in-game to verify that my recipe addition would work, and it appears that it does work.  
This fulfills issue #174 .

Screenshot to prove that the ratios are correct.  
![image](https://user-images.githubusercontent.com/29822509/131728086-5e8cc7e1-07ca-4e7d-91b9-fe23ffc1e174.png)

In addition, my second commit removes an extra stick recipe, added by the *Better Nether* mod.  For some reason, the mod adds a recipe where 2 Stalagnate planks -> 4 sticks.  That recipe with those items is already covered by the generic 2*<ore:plankWood> -> 4 * <minecraft:stick>
The recipe can be seen here, as the bottom one.  I just remove that recipe.  You are still able to craft sticks from stalagnate planks, so functionality is still as expected.  
![image](https://user-images.githubusercontent.com/29822509/131765855-57c90ee7-c662-41ad-ac74-316dc1cb8973.png)

If any more changes are needed, please let me know. 