### PR TITLE
Fix conflicting recipes for grates/iron grates

### DIFF
--- a/scripts/Quark.zs
+++ b/scripts/Quark.zs
@@ -26,4 +26,11 @@ recipes.addShapeless(<quark:enderdragon_scale>, [<divinerpg:kraken_scale>,<mysti
 recipes.remove(<quark:sandy_bricks>);
 recipes.addShapeless(<quark:sandy_bricks>, [<minecraft:brick_block>,<ore:sand>]);
 
+# Quark iron grate recipe conflits with galacticraft grate recipe.
+# Also going to have the galacticraft exchanging recipe here.    
+recipes.removeByRecipeName("quark:grate");
+recipes.addShapeless(<quark:grate>, [<galacticraftcore:grating>]);
+recipes.addShapeless(<galacticraftcore:grating>, [<quark:grate>]);
+
+
 print("ENDING Quark.zs");


### PR DESCRIPTION
Removes conflicting recipe.  Adds shapeless conversion between galacticraft's item and quark's item.  
Look at issue #200 for the prior screenshots.  The current recipes are as follows.  
![image](https://user-images.githubusercontent.com/29822509/131899544-c2506ef4-02da-41d0-8b17-f6a64db8b5b9.png)
![image](https://user-images.githubusercontent.com/29822509/131899554-c32ad918-eedb-4a9d-904e-44ea91f66a96.png)


I believe that this fixes the issues seen.  Please let me know if it is not satisfactory.  