### PR TITLE
Increases Imp spawn weight

### DIFF
--- a/config/BiomeTweaker/output/biome/Hell (minecraft_hell).json
+++ b/config/BiomeTweaker/output/biome/Hell (minecraft_hell).json
@@ -34,7 +34,7 @@
     },
     {
       "Entity Class": "com.progwml6.natura.entities.entity.passive.EntityImp",
-      "Weight": 10,
+      "Weight": 25,
       "Min Group Count": 8,
       "Max Group Count": 12
     }


### PR DESCRIPTION
Increases Imp spawn weight from 10 to 25.
Fix for #179.

Hopefully they should be less annoying to find in the nether but i only changed the values for minecraft:hell biome. However if BetterNether biomes are not considered as in the same category as Hell, it may not work properly...
![image](https://user-images.githubusercontent.com/88466145/131948485-2b376079-5346-4e87-a6ce-8580a36423f9.png)

Discord: jack108#2832