### PR TITLE
Fix for red coal

### DIFF
--- a/scripts/Chisel.zs
+++ b/scripts/Chisel.zs
@@ -24,4 +24,10 @@ recipes.addShaped(<chisel:stonebrick2:8>, [[<minecraft:stone_slab>],[<minecraft:
 recipes.remove(<chisel:auto_chisel>);
 recipes.addShaped(<chisel:auto_chisel>, [[<enderio:block_fused_quartz>,<enderio:block_fused_quartz>,<enderio:block_fused_quartz>],[<chisel:chisel_iron>,<thermalexpansion:frame>,<chisel:chisel_iron>],[<thermalfoundation:material:352>,<thermalfoundation:material:352>,<thermalfoundation:material:352>]]);
 
+
+# Remove chisel charcoal recipe.  Conflicts with thermal recipe.  
+recipes.remove(<chisel:block_charcoal:*>);
+recipes.remove(<chisel:block_charcoal1:*>);
+recipes.remove(<chisel:block_charcoal2:*>);
+
 print("ENDING Chisel.zs");

--- a/scripts/ExtraUtilities2.zs
+++ b/scripts/ExtraUtilities2.zs
@@ -93,7 +93,7 @@ recipes.addShaped(<extrautils2:redstoneclock>, [[<projectred-core:resource_item>
 # Red Coal
 mods.extrautils2.Resonator.remove(<extrautils2:ingredients:4>);
 mods.extrautils2.Resonator.add(<extrautils2:ingredients:4>, <minecraft:coal_block>, 1600);
-mods.extrautils2.Resonator.add(<extrautils2:ingredients:4>, <actuallyadditions:block_misc:5>, 1600);
+mods.extrautils2.Resonator.add(<extrautils2:ingredients:4>, <thermalfoundation:storage_resource:0>, 1600);
 
 # Lunar Reactive Dust
 mods.extrautils2.Resonator.remove(<extrautils2:ingredients:3>);


### PR DESCRIPTION
Removes chisel recipes.  Had some issues with them, so I just opted to remove any possible recipe for any of the chisel charcoal blocks.
Changes the red coal recipe to use the thermal block instead of the actually additions mod.  

Fixes issue #197 