### PR TITLE
Fix inferno sword recipe to work with any oreRedstone

### DIFF
--- a/scripts/DivineRPG.zs
+++ b/scripts/DivineRPG.zs
@@ -285,4 +285,10 @@ recipes.remove(<divinerpg:reyvor_crystal>);
 recipes.remove(<divinerpg:karot_crystal>);
 recipes.remove(<divinerpg:densos_crystal>);
 
+# Inferno sword
+recipes.remove(<divinerpg:inferno_sword>);
+recipes.addShaped(<divinerpg:inferno_sword>, [[<minecraft:blaze_powder>, <ore:oreRedstone>, <minecraft:blaze_powder>],
+											  [<minecraft:blaze_powder>, <ore:oreRedstone>, <minecraft:blaze_powder>],
+											  [<minecraft:blaze_powder>, <ore:stickWood>, <minecraft:blaze_powder>]]);
+
 print("ENDING DivineRPG.zs");


### PR DESCRIPTION
Make inferno sword work with any redstone ore rather than just the vanilla redstone ore.
Fixes issue #212 .  

However, given that the sword is pretty good, I would consider changing the recipe.  Blazing pyrotheum would make more sense, but that gates the recipe to chapter 10(thermal tech).  

Feedback would be great, as I don't know where's the best place to gate this recipe to.  